### PR TITLE
Made method header configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Through these means, code becomes easier to understand, maintain, and evolve.
 | SFDoc.username                          | Username that will appear in File and Method headers.                                                                             |
 | SFDoc.DateFormat                        | The format in which SFDoc will output dates. Needs to include [DD, MM, YYYY] in the desired order and with the desired separator. |
 | SFDoc.FileHeaderProperties              | Array of properties to be added to the File Headers. Format of entries is : `{name: string, defaultValue?: string}`.              |
+| SFDoc.FileHeaderPropertiesSeparator     | Caracter added after a file header properties name. Default value ":".                                                            |
+| SFDoc.FileHeaderPropertiesAlignLeft     | Align file header properties value to the left. Default value true.                                                               |
+| SFDoc.MethodHeaderProperties            | Array of properties to be added to the Method Headers. Format of entries is : `{name: string, defaultValue?: string}`.            |
+| SFDoc.MethodHeaderPropertiesSeparator   | Caracter added after a method header properties name. Default value "".                                                          |
+| SFDoc.MethodHeaderPropertiesAlignLeft   | Align method header properties value to the left. Default value false.                                                             |
 | SFDoc.EnableForApex                     | Enable automatic on-save file header insertion and update for Apex classes.                                                       |
 | SFDoc.EnableForVisualforce              | Enable automatic on-save file header insertion and update for Visualforce pages.                                                  |
 | SFDoc.EnableForLightningMarkup          | Enable automatic on-save file header insertion and update for Lightning Markup files.                                             |

--- a/package.json
+++ b/package.json
@@ -157,6 +157,39 @@
           ],
           "description": "Array of properties for the generated File Headers in the format: {name: String, defaultValue?: string}"
         },
+		"SFDoc.FileHeaderPropertiesSeparator": {
+          "type": "string",
+          "default": ":",
+          "description": "Caracter added after a file header properties name."
+        },
+		"SFDoc.FileHeaderPropertiesAlignLeft": {
+          "type": "boolean",
+          "default": true,
+          "description": "Align file header properties value to the left."
+        },
+        "SFDoc.MethodHeaderProperties": {
+          "type": "array",
+          "default": [
+            {
+              "name": "description"
+            },
+            {
+              "name": "author",
+              "defaultValue": "$username | $date"
+            }
+          ],
+          "description": "Array of properties for the generated Method Headers in the format: {name: String, defaultValue?: string}"
+        },
+		"SFDoc.MethodHeaderPropertiesSeparator": {
+          "type": "string",
+          "default": "",
+          "description": "Caracter added after a method header properties name."
+        },
+		"SFDoc.MethodHeaderPropertiesAlignLeft": {
+          "type": "boolean",
+          "default": false,
+          "description": "Align method header properties value to the left."
+        },
         "SFDoc.DateFormat": {
           "type": "string",
           "default": "MM-DD-YYYY",

--- a/src/templates/templates.method.ts
+++ b/src/templates/templates.method.ts
@@ -10,15 +10,18 @@ export function getMethodHeaderFromTemplate(
   parameters: string[],
   returnType: string
 ) {
+	const formattedDate = helper.getFormattedDate();
+  const username = helper.getConfiguredUsername();
   return (
-    "/**\n" +
-    "* @description \n" +
-    `* @author ${helper.getConfiguredUsername()} | ${helper.getFormattedDate()} \n` +
+    "/**\n" +helper.getFormattedMethodHeaderProperties(
+    username,
+    formattedDate
+  )+"\n"+
     `${parameters
-      .map((param) => `* @param ${param} \n`)
-      .toString()
+      .map((param) => ` * @param ${param} \n`)
+      .toString()	
       .replace(/,/gim, "")}` +
-    (returnType === "void" ? "" : `* @return ${returnType} `) +
+    (returnType === "void" ? "" : ` * @return ${returnType} `) +
     "\n**/"
   );
 }


### PR DESCRIPTION
Hi @HugoOM,
In our team we use a different format for comments than the default ones in your extension. So we needed to have the method header configurable.
I opened this "Pull request" because I added this modification in addition to some bugfixes:
#50: JSDoc (and ApexDoc) standards don't allow a colon in the property list
#49: Method Code Block cannot collapse due to missing space in front of asterick

Changes:
Made method header configurable
    Added MethodHeaderProperties parameter
    Caracter added after a Method header properties name.
    Align or not method header properties values to the left.
Added more options for file header:
    Caracter added after a file header property name.
    Align or not file header properties values to the left.

Thanks 